### PR TITLE
Use https for website URL.

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This is Syndie, an anonymity-aware distributed forum.
 
 Up to date information about Syndie can be found over at
-http://syndie.de/
+https://syndie.de/
 
 This package contains:
 - INSTALL: how to build and install Syndie from source


### PR DESCRIPTION
The README was using a non-TLS URL; this PR fixes that.